### PR TITLE
Show meaningful error in case of doubled schema (#3239)

### DIFF
--- a/test/ecto/schema_test.exs
+++ b/test/ecto/schema_test.exs
@@ -685,4 +685,25 @@ defmodule Ecto.SchemaTest do
       end
     end
   end
+
+  test "defining schema twice will result with meaningfull error" do
+    quoted = """
+    defmodule DoubleSchema do
+      use Ecto.Schema
+
+      schema "my schema" do
+        field :name, :string
+      end
+
+      schema "my schema" do
+        field :name, :string
+      end
+    end
+    """
+    message = "schema already defined for DoubleSchema on line 4"
+
+    assert_raise RuntimeError, message, fn ->
+      Code.compile_string(quoted, "example.ex")
+    end
+  end
 end


### PR DESCRIPTION
Earlier it returned information about `id` being defined twice, which
could be confusing for the users as in most cases this field wasn't
defined anywhere. Now it will raise `RuntimeError` with meaningful error
that contain line with first schema.