### PR TITLE
Update best practice for deletion of association (#3708)

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -161,8 +161,11 @@ defmodule Ecto.Changeset do
 
   The `:delete` and `:delete_if_exists` options must be used carefully as they allow
   users to delete any associated data by simply not sending the associated data.
-  If you need deletion, it is often preferred to manually mark the changeset
-  for deletion if a `delete` field is set in the params, as in the example below:
+  If you need deletion, it is often preferred to add a separate boolean virtual field
+  in the schema and manually mark the changeset for deletion if the `:delete` field is
+  set in the params, as in the example below. Note that we don't call `cast/4` in this
+  case because we don't want to prevent deletion if a change is invalid (changes are
+  irrelevant if the entity needs to be deleted).
 
       defmodule Comment do
         use Ecto.Schema
@@ -170,10 +173,11 @@ defmodule Ecto.Changeset do
 
         schema "comments" do
           field :body, :string
+          field :delete, :boolean, virtual: true
         end
 
         def changeset(comment, %{"delete" => "true"}) do
-          %{Ecto.Changeset.change(comment) | action: :delete}
+          %{Ecto.Changeset.change(comment, delete: true) | action: :delete}
         end
 
         def changeset(comment, params) do


### PR DESCRIPTION
```elixir
  def changeset(comment, params) do
    cast(comment, params, [:body, :delete])
    |> maybe_mark_for_deletion
  end

  defp maybe_mark_for_deletion(changeset) do
    if get_change(changeset, :delete) do
      %{changeset | action: :delete}
    else
      changeset
    end
  end
```

Problem:

If a user updates the entity with invalid values, then decides to delete it (`:delete` field in params set to `true`) and submits, the entity won't be deleted and the changeset will be marked as invalid, as there are invalid changes.
This caused then a very tricky bug where the entity won't appear on the screen (still marked as deleted), and the changeset errors won't show up, and the user can no longer fix the form and is stuck.

Solution:

Just get "delete" value from the params (as Jose suggested and is the right approach imo) and don't even try to cast: invalid changes are irrelevant when the entity is to be deleted. See code below.

--- My PR 31st May 2020 ---

```elixir
  schema "comments" do
    field :body, :string
  end

  def changeset(comment, %{"delete" => "true"}) do
    %{Ecto.Changeset.change(comment) | action: :delete}
  end

  def changeset(comment, params) do
    cast(comment, params, [:body])
  end
```

Problem:

While this solved the problem above, by removing the virtual field `:delete` a new problem occurs:
if the user marks an entity as to be deleted, but is back to the form because of an error in the changeset, the entity will show up again (obviously as we no longer have the virtual `:delete` field).

Solution:

Reintroduce the virtual `:delete` field.

--- This PR ---

```elixir
  schema "comments" do
    field :body, :string
    field :delete, :boolean, virtual: true
  end

  def changeset(comment, %{"delete" => "true"}) do
    %{Ecto.Changeset.change(comment, %{delete: true}) | action: :delete}
  end

  def changeset(comment, params) do
    cast(comment, params, [:body])
  end
```

If any question, do not hesitate to ask.

See
https://groups.google.com/u/3/g/elixir-ecto/c/BwlXW105agM
https://github.com/elixir-ecto/ecto/commit/890cc735b885bf629f271e2b631fdc49ba1276e1